### PR TITLE
✨ 星标合集：列表取数查询 + starred_at 排序

### DIFF
--- a/src/infra/repository/dbBookmark.ts
+++ b/src/infra/repository/dbBookmark.ts
@@ -289,6 +289,7 @@ export class BookmarkRepo {
       where.archive_status = archiveStatus
     } else if (filter === 'starred') {
       where.is_starred = true
+      orderBy = { updated_at: 'desc' }
     } else if (filter === 'trashed') {
       where.deleted_at = { not: null }
       orderBy = { deleted_at: 'desc' }
@@ -491,11 +492,17 @@ export class BookmarkRepo {
   public async countBookmarksByTag(userId: number, tagId: number) {
     const [result] = await this.prismaPg().$queryRaw<[{ exists: boolean }]>`
       SELECT EXISTS (
-        SELECT 1 
-        FROM sr_user_bookmark_tag 
+        SELECT 1
+        FROM sr_user_bookmark_tag
         WHERE user_id = ${userId} AND tag_id = ${tagId} AND is_deleted = false
       ) as "exists"`
     return result.exists
+  }
+
+  public async countStarredBookmarks(userId: number) {
+    return await this.prismaPg().sr_user_bookmark.count({
+      where: { user_id: userId, deleted_at: null, is_starred: true }
+    })
   }
 
   public async deleteUserTag(userId: number, tagId: number) {
@@ -552,6 +559,15 @@ export class BookmarkRepo {
       orderBy: {
         created_at: 'desc'
       }
+    })
+  }
+
+  // 合集列表 snippet 兜底
+  public async listUserBookmarkOverviews(userId: number, bookmarkIds: number[]) {
+    if (bookmarkIds.length === 0) return []
+    return await this.prismaPg().sr_user_bookmark_overview.findMany({
+      where: { user_id: userId, bookmark_id: { in: bookmarkIds } },
+      select: { bookmark_id: true, overview: true }
     })
   }
 

--- a/src/infra/repository/dbBookmark.ts
+++ b/src/infra/repository/dbBookmark.ts
@@ -289,7 +289,7 @@ export class BookmarkRepo {
       where.archive_status = archiveStatus
     } else if (filter === 'starred') {
       where.is_starred = true
-      orderBy = { updated_at: 'desc' }
+      orderBy = { starred_at: 'desc' }
     } else if (filter === 'trashed') {
       where.deleted_at = { not: null }
       orderBy = { deleted_at: 'desc' }

--- a/src/infra/repository/dbMark.ts
+++ b/src/infra/repository/dbMark.ts
@@ -128,6 +128,21 @@ export class MarkRepo {
     return row?.comment ?? ''
   }
 
+  // bookmark_id 实为 user_bookmark id
+  async listByUserBookmarkIds(userBookmarkIds: number[], userId: number) {
+    if (userBookmarkIds.length === 0) return []
+    return await this.prismaPg().sr_bookmark_comment.findMany({
+      where: {
+        bookmark_id: { in: userBookmarkIds },
+        user_id: userId,
+        is_deleted: false,
+        type: { in: [markType.LINE, markType.COMMENT] }
+      },
+      select: { bookmark_id: true, type: true, comment: true, content: true },
+      orderBy: { created_at: 'asc' }
+    })
+  }
+
   async list(userBmId: number) {
     return (
       await this.prismaPg().sr_bookmark_comment.findMany({


### PR DESCRIPTION
## 概述
配合 slax_reader_backend 星标合集功能的 public-api（slax-reader-api）改动，合并入 `main`。

## 主要改动
- 新增合集列表相关仓储查询（collection list repo queries）
- 星标书签排序由 `updated_at` 改为 `starred_at`，修正星标排序口径

## 影响面
- `src/infra/repository/dbBookmark.ts`
- `src/infra/repository/dbMark.ts`

> 需与主仓库 `feature/starred-collection` → `develop` 的 PR 一并上线。

🤖 Generated with [Claude Code](https://claude.com/claude-code)