### PR TITLE
🐛 Fix tags example exceeding the stated 0-3 tag limit

### DIFF
--- a/src/const/prompt.ts
+++ b/src/const/prompt.ts
@@ -163,7 +163,7 @@ ${tags.join(',')}
     gist: 输出的overview内容,
     key_takeaways: 3~5 条核心要点,
   },
-  tags: [标签1, 标签2, 标签3, 标签4, ...]
+  tags: [标签1, 标签2, 标签3]
 }
 `
 }


### PR DESCRIPTION
## Summary
`generateOverviewTagsUserPrompt` states the model may output 0-3 tags, but the JSON format example still showed 4 placeholder tags (`标签4, ...`), contradicting the stated rule. This example has been trailing behind since before the 0-3 limit was introduced.

Changed the example from `[标签1, 标签2, 标签3, 标签4, ...]` to `[标签1, 标签2, 标签3]` to match the stated limit.

## Test plan
- [x] `npx eslint src/const/prompt.ts` passes
- [x] Confirmed downstream: slax_reader_backend's `test/domain/aigcPrompt.test.ts` asserts `tags: [标签1, 标签2, 标签3]` and currently fails against this repo's `main` — this fix resolves that once the submodule pointer is bumped