### PR TITLE
✨ clear search cache on PowerSync bookmark trash/restore

### DIFF
--- a/src/domain/orchestrator/sync.ts
+++ b/src/domain/orchestrator/sync.ts
@@ -7,6 +7,7 @@ import { DBSyncBatchOperation } from '../../infra/repository/dbSyncBatch'
 import { QueueClient, queueRetryParseMessage, callbackType } from '../../infra/queue/queueClient'
 import { parserType, URLPolicie } from '../../utils/urlPolicie'
 import { markType } from '../../infra/repository/dbMark'
+import { SearchService } from '../search'
 
 export type SyncExecOperation = 'PUT' | 'PATCH' | 'DELETE'
 
@@ -98,6 +99,7 @@ export type OrderedSyncOperation =
   | SyncOperation<'update_tags', UpdateTagsData, string>
   | SyncOperation<'update_share', UpdateShareData, string>
   | SyncOperation<'delete_bookmark', undefined, string>
+  | SyncOperation<'restore_bookmark', undefined, string>
   | CommentSyncOperation<'create_comment', CreateCommentData, string>
   | CommentSyncOperation<'delete_comment', DeleteCommentData, string>
 
@@ -131,7 +133,8 @@ export class SyncOrchestrator {
   constructor(
     @inject(UserService) private userService: UserService,
     @inject(DBSyncBatchOperation) private dbSyncBatch: DBSyncBatchOperation,
-    @inject(QueueClient) private queueClient: QueueClient
+    @inject(QueueClient) private queueClient: QueueClient,
+    @inject(SearchService) protected searchService: SearchService
   ) {}
 
   /** sign token */
@@ -177,6 +180,11 @@ export class SyncOrchestrator {
     const result = await this.dbSyncBatch.executeOrderedOperations(orderedOperations)
     for (const newBookmark of result) {
       await this.sendRetryParseEvent(ctx, newBookmark)
+    }
+
+    // 同步删除/恢复需补清缓存
+    if (orderedOperations.some(op => op.type === 'delete_bookmark' || op.type === 'restore_bookmark')) {
+      await this.searchService.clearSearchCache(ctx, userId)
     }
   }
 
@@ -266,10 +274,11 @@ export class SyncOrchestrator {
       return
     }
 
-    // soft delete bookmark
+    // soft delete/restore
     if (change.data.hasOwnProperty('deleted_at')) {
+      const isRestore = !change.data['deleted_at']
       operations.push({
-        type: 'delete_bookmark',
+        type: isRestore ? 'restore_bookmark' : 'delete_bookmark',
         bookmarkUuid: change.id,
         userId,
         data: undefined

--- a/src/infra/repository/dbSyncBatch.ts
+++ b/src/infra/repository/dbSyncBatch.ts
@@ -34,6 +34,7 @@ export class DBSyncBatchOperation {
       update_tags: this.executeUpdateTags,
       update_share: this.executeUpdateShare,
       delete_bookmark: this.executeDeleteBookmark,
+      restore_bookmark: this.executeRestoreBookmark,
       create_comment: this.executeCreateComment,
       delete_comment: this.executeDeleteComment
     }
@@ -250,6 +251,16 @@ export class DBSyncBatchOperation {
     await tx.sr_user_bookmark.update({
       where: { uuid: operation.bookmarkUuid, user_id: operation.userId },
       data: { deleted_at: new Date() }
+    })
+  }
+
+  /** restore bookmark */
+  public async executeRestoreBookmark(tx: prismaTx, operation: OrderedSyncOperation): Promise<void> {
+    if (operation.type !== 'restore_bookmark') return
+
+    await tx.sr_user_bookmark.update({
+      where: { uuid: operation.bookmarkUuid, user_id: operation.userId },
+      data: { deleted_at: null, archive_status: 0 }
     })
   }
 


### PR DESCRIPTION
## Summary
- Local-first trash/restore goes through PowerSync sync, bypassing `trashBookmark`/`trashRevertBookmark` and their `clearSearchCache` call
- Fix `processUserBookmarkChange`: it only checked whether `deleted_at` was present, not its value, so a restore (`deleted_at = null`) was misclassified as a delete
- Add a `restore_bookmark` operation type and its executor (resets `archive_status` too, matching `trashRevertBookmark`)
- `syncChanges` now clears the search cache once when the batch includes a delete/restore

## Test plan
- [x] Added unit tests for delete/restore classification and cache-clear triggering
- [x] `pnpm vitest run` passes