### PR TITLE
feat(youtube): canonical sr_youtube_article tables and repository

### DIFF
--- a/20260909-youtube-article-p0.md
+++ b/20260909-youtube-article-p0.md
@@ -1,0 +1,25 @@
+# YouTube AI 整理稿 P0：两张表和仓储
+
+日期：2026-09-09
+
+为 YouTube AI 整理稿新增表 `sr_youtube_article`、`sr_youtube_article_ref` 和对应仓储。字幕和文章本身是 R2 对象，表里只放指针、版本、状态和门控结果。托管后端负责写入，本仓库只提供表结构和数据访问。
+
+产品上已确定字幕和整理稿按视频共享，owner 和分享访客都能看。`sr_bookmark` 的唯一键是（target_url，private_user），书签本来就是每个用户一份，所以视频的身份用 video_id，不用 bookmark_id。
+
+`sr_youtube_article`，视频级，一行对应一个（video_id，source_hash，prompt_version）。source_hash 由字幕内容、时间、轨道和格式版本算出，字幕一变就是新行，旧文章不会盖到新字幕上。列：video_id、caption_key、caption_text_key、caption_language、caption_kind、source_hash、eligibility_json、status、article_key、article_text_key、model、prompt_version、schema_version、quality_json、retry_count、lease_until、next_retry_at、error_message、created_at、updated_at、started_at、completed_at。索引 (status, next_retry_at)。
+
+`sr_youtube_article_ref`，书签级，bookmark_id 唯一：user_id、video_id、source_hash。记录书签抓取时看到的字幕版本，重抓时指针移到新版本。权限始终由书签决定，这张表和 R2 key 都不当权限用。索引 (video_id, source_hash)、user_id。
+
+状态集合：pending、classifying、skipped、generating、validating、ready、failed、stale。本次只会写 pending 和 skipped。
+
+仓储 `YoutubeArticleRepo`：
+
+- `recordEvaluation()`：按视频级唯一键 upsert 门控结果。行已经进入 generating、ready 等后续状态时不覆盖，原样返回。
+- `linkBookmark()`：按 bookmark_id upsert 书签指针。
+- `findForBookmark()`：从书签的 ref 找到当前 prompt 版本的视频行。
+- `unlinkBookmark()`：删除书签时删 ref。
+- `countRefs()`：清理任务判断视频产物还有没有人引用。
+
+迁移文件 `prisma/migrations/20260909000000_add_youtube_article/migration.sql`，与托管后端的 `pg_migrations` 同名同内容。
+
+验证：文件用本仓库 lint 配置检查无问题；类型通过托管后端的 tsc 一并检查。没有连真实数据库执行迁移。

--- a/prisma/hyperdrive.prisma
+++ b/prisma/hyperdrive.prisma
@@ -346,3 +346,52 @@ model sr_user_lab_feature {
     @@unique([user_id, feature])
     @@index([feature, enabled])
 }
+
+// Derived AI article for a YouTube video. Captions and articles are R2 objects under
+// youtube/canonical/; this row only carries pointers, versions, status and the eligibility result.
+// One row per (video_id, source_hash, prompt_version), shared by every bookmark of that video:
+// the caption source hash changes whenever the captions change, so an old article can never be
+// published over new captions. Visibility is decided by the bookmark, never by this row.
+model sr_youtube_article {
+    id               Int       @id @default(autoincrement())
+    video_id         String
+    caption_key      String?
+    caption_text_key String?
+    caption_language String?
+    caption_kind     String?
+    source_hash      String
+    eligibility_json Json?
+    status           String    @default("pending")
+    article_key      String?
+    article_text_key String?
+    model            String?
+    prompt_version   String
+    schema_version   Int       @default(1)
+    quality_json     Json?
+    retry_count      Int       @default(0)
+    lease_until      DateTime?
+    next_retry_at    DateTime?
+    error_message    String?
+    created_at       DateTime  @default(now())
+    updated_at       DateTime  @updatedAt
+    started_at       DateTime?
+    completed_at     DateTime?
+
+    @@unique([video_id, source_hash, prompt_version])
+    @@index([status, next_retry_at])
+}
+
+// Which caption version a bookmark saw when it was crawled. One row per bookmark (bookmarks are
+// per user here). Deleted with the bookmark; canonical rows with no refs left are swept.
+model sr_youtube_article_ref {
+    id          Int      @id @default(autoincrement())
+    bookmark_id Int      @unique
+    user_id     Int
+    video_id    String
+    source_hash String
+    created_at  DateTime @default(now())
+    updated_at  DateTime @updatedAt
+
+    @@index([video_id, source_hash])
+    @@index([user_id])
+}

--- a/prisma/migrations/20260909000000_add_youtube_article/migration.sql
+++ b/prisma/migrations/20260909000000_add_youtube_article/migration.sql
@@ -1,0 +1,54 @@
+-- sr_youtube_article: canonical job table for the derived YouTube AI article, one row per
+-- (video_id, source_hash, prompt_version). Captions and articles are R2 objects; this row only
+-- holds pointers, versions, status and the eligibility result.
+CREATE TABLE "sr_youtube_article" (
+    "id" SERIAL NOT NULL,
+    "video_id" TEXT NOT NULL,
+    "caption_key" TEXT,
+    "caption_text_key" TEXT,
+    "caption_language" TEXT,
+    "caption_kind" TEXT,
+    "source_hash" TEXT NOT NULL,
+    "eligibility_json" JSONB,
+    "status" TEXT NOT NULL DEFAULT 'pending',
+    "article_key" TEXT,
+    "article_text_key" TEXT,
+    "model" TEXT,
+    "prompt_version" TEXT NOT NULL,
+    "schema_version" INTEGER NOT NULL DEFAULT 1,
+    "quality_json" JSONB,
+    "retry_count" INTEGER NOT NULL DEFAULT 0,
+    "lease_until" TIMESTAMP(3),
+    "next_retry_at" TIMESTAMP(3),
+    "error_message" TEXT,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+    "started_at" TIMESTAMP(3),
+    "completed_at" TIMESTAMP(3),
+
+    CONSTRAINT "sr_youtube_article_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "sr_youtube_article_video_id_source_hash_prompt_version_key" ON "sr_youtube_article"("video_id", "source_hash", "prompt_version");
+
+CREATE INDEX "sr_youtube_article_status_next_retry_at_idx" ON "sr_youtube_article"("status", "next_retry_at");
+
+-- sr_youtube_article_ref: which caption version a bookmark saw when it was crawled. One row per
+-- bookmark; deleted with the bookmark. Canonical rows with no refs left are swept separately.
+CREATE TABLE "sr_youtube_article_ref" (
+    "id" SERIAL NOT NULL,
+    "bookmark_id" INTEGER NOT NULL,
+    "user_id" INTEGER NOT NULL,
+    "video_id" TEXT NOT NULL,
+    "source_hash" TEXT NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "sr_youtube_article_ref_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "sr_youtube_article_ref_bookmark_id_key" ON "sr_youtube_article_ref"("bookmark_id");
+
+CREATE INDEX "sr_youtube_article_ref_video_id_source_hash_idx" ON "sr_youtube_article_ref"("video_id", "source_hash");
+
+CREATE INDEX "sr_youtube_article_ref_user_id_idx" ON "sr_youtube_article_ref"("user_id");

--- a/src/infra/repository/dbYoutubeArticle.ts
+++ b/src/infra/repository/dbYoutubeArticle.ts
@@ -1,0 +1,137 @@
+import { inject, singleton } from '../../decorators/di'
+import { PRISIMA_HYPERDRIVE_CLIENT } from '../../const/symbol'
+import type { LazyInstance } from '../../decorators/lazy'
+import type { Prisma } from '@prisma/hyperdrive-client'
+import { PrismaClient as HyperdrivePrismaClient } from '@prisma/hyperdrive-client'
+
+/** Prompt contract version of the AI article. Bump when the prompt or output schema changes. */
+export const YOUTUBE_ARTICLE_PROMPT_VERSION = 'v1'
+export const YOUTUBE_ARTICLE_SCHEMA_VERSION = 1
+
+/** pending / classifying / skipped / generating / validating / ready / failed / stale */
+export type YoutubeArticleStatus = 'pending' | 'classifying' | 'skipped' | 'generating' | 'validating' | 'ready' | 'failed' | 'stale'
+
+/** Rows that a fresh evaluation may overwrite. Anything further along keeps its state. */
+const REEVALUABLE_STATUSES: YoutubeArticleStatus[] = ['pending', 'skipped']
+
+/** Canonical row: one per (video_id, source_hash, prompt_version), shared by every bookmark of that video. */
+export interface youtubeArticlePO {
+  id: number
+  video_id: string
+  caption_key: string | null
+  caption_text_key: string | null
+  caption_language: string | null
+  caption_kind: string | null
+  source_hash: string
+  eligibility_json: Prisma.JsonValue | null
+  status: string
+  article_key: string | null
+  article_text_key: string | null
+  model: string | null
+  prompt_version: string
+  schema_version: number
+  quality_json: Prisma.JsonValue | null
+  retry_count: number
+  lease_until: Date | null
+  next_retry_at: Date | null
+  error_message: string | null
+  created_at: Date
+  updated_at: Date
+  started_at: Date | null
+  completed_at: Date | null
+}
+
+/** Which caption version a bookmark saw when it was crawled. One per bookmark. */
+export interface youtubeArticleRefPO {
+  id: number
+  bookmark_id: number
+  user_id: number
+  video_id: string
+  source_hash: string
+  created_at: Date
+  updated_at: Date
+}
+
+export interface YoutubeArticleEvaluation {
+  video_id: string
+  caption_key: string | null
+  caption_text_key: string | null
+  caption_language: string | null
+  caption_kind: string | null
+  source_hash: string
+  prompt_version: string
+  schema_version: number
+  status: Extract<YoutubeArticleStatus, 'pending' | 'skipped'>
+  /** Plain JSON-serializable object (the eligibility result). */
+  eligibility: object
+}
+
+/**
+ * Job table for the derived YouTube article. Only pointers, versions, status and the gate result
+ * live here; captions and articles are R2 objects under youtube/canonical/. Bookmarks point at a
+ * (video_id, source_hash) through sr_youtube_article_ref; visibility is always decided by the
+ * bookmark, never by these rows.
+ */
+@singleton()
+export class YoutubeArticleRepo {
+  constructor(@inject(PRISIMA_HYPERDRIVE_CLIENT) private prismaPg: LazyInstance<HyperdrivePrismaClient>) {}
+
+  /**
+   * Record the eligibility result for a caption source. Creates the row, or refreshes it while it
+   * is still pending/skipped; a row that already moved on (generating, ready, ...) is returned as is.
+   */
+  public async recordEvaluation(input: YoutubeArticleEvaluation): Promise<youtubeArticlePO> {
+    const where = {
+      video_id_source_hash_prompt_version: {
+        video_id: input.video_id,
+        source_hash: input.source_hash,
+        prompt_version: input.prompt_version
+      }
+    }
+    const existing = await this.prismaPg().sr_youtube_article.findUnique({ where })
+    if (existing && !REEVALUABLE_STATUSES.includes(existing.status as YoutubeArticleStatus)) return existing
+
+    const data = {
+      caption_key: input.caption_key,
+      caption_text_key: input.caption_text_key,
+      caption_language: input.caption_language,
+      caption_kind: input.caption_kind,
+      schema_version: input.schema_version,
+      eligibility_json: input.eligibility as Prisma.InputJsonObject,
+      status: input.status
+    }
+    return this.prismaPg().sr_youtube_article.upsert({
+      where,
+      create: { ...data, video_id: input.video_id, source_hash: input.source_hash, prompt_version: input.prompt_version },
+      update: data
+    })
+  }
+
+  /** Point a bookmark at the caption version it was crawled with. A re-crawl moves the pointer. */
+  public async linkBookmark(input: { bookmark_id: number; user_id: number; video_id: string; source_hash: string }): Promise<youtubeArticleRefPO> {
+    return this.prismaPg().sr_youtube_article_ref.upsert({
+      where: { bookmark_id: input.bookmark_id },
+      create: input,
+      update: { user_id: input.user_id, video_id: input.video_id, source_hash: input.source_hash }
+    })
+  }
+
+  /** The canonical row a bookmark currently points at, for the given prompt version. */
+  public async findForBookmark(bookmarkId: number, promptVersion: string = YOUTUBE_ARTICLE_PROMPT_VERSION): Promise<youtubeArticlePO | null> {
+    const ref = await this.prismaPg().sr_youtube_article_ref.findUnique({ where: { bookmark_id: bookmarkId } })
+    if (!ref) return null
+    return this.prismaPg().sr_youtube_article.findUnique({
+      where: { video_id_source_hash_prompt_version: { video_id: ref.video_id, source_hash: ref.source_hash, prompt_version: promptVersion } }
+    })
+  }
+
+  /** Called when a bookmark is deleted. Canonical rows with no refs left are swept separately. */
+  public async unlinkBookmark(bookmarkId: number): Promise<number> {
+    const res = await this.prismaPg().sr_youtube_article_ref.deleteMany({ where: { bookmark_id: bookmarkId } })
+    return res.count
+  }
+
+  public async countRefs(videoId: string, sourceHash?: string): Promise<number> {
+    return this.prismaPg().sr_youtube_article_ref.count({ where: { video_id: videoId, ...(sourceHash ? { source_hash: sourceHash } : {}) } })
+  }
+}


### PR DESCRIPTION
## 做了什么

为 YouTube AI 整理稿新增两张表和仓储，是整个功能的第一步（P0）。字幕和文章本身是 R2 对象，表里只放指针、版本、状态和门控结果。

- `sr_youtube_article`：视频级，一行对应一个（video_id，source_hash，prompt_version）。字幕一变就是新行，旧文章不会盖到新字幕上。
- `sr_youtube_article_ref`：书签级，bookmark_id 唯一，记录书签抓取时看到的字幕版本。权限始终由书签决定，这张表和 R2 key 都不当权限用。
- `YoutubeArticleRepo`：`recordEvaluation()`（不覆盖已进入 generating/ready 的行）、`linkBookmark()`、`findForBookmark()`、`unlinkBookmark()`、`countRefs()`。
- 迁移 `prisma/migrations/20260909000000_add_youtube_article`，与托管后端 `pg_migrations` 同名同内容。

为什么用 video_id 而不是 bookmark_id：`sr_bookmark` 唯一键是（target_url，private_user），托管收藏时书签本来就是每个用户一份。

## 验证

- 本仓库 lint 配置检查无问题；类型通过托管后端的 tsc 一并检查。
- 没有连真实数据库执行迁移。

## 发布

先合这个 PR，再把托管后端 unnoo/slax_reader_backend 的 `public-api` 指针换到 main。对应后端 PR 在同名分支 `feat/youtube-article-p0`。

细节见 `20260909-youtube-article-p0.md`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018BfjDnY5W2Jbkh6i4atg31
